### PR TITLE
Create wish list page & Keep wish list states

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@ant-design/icons": "^4.6.2",
     "@material-ui/core": "^4.11.4",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",

--- a/src/Components/BeerDetailInfo.js
+++ b/src/Components/BeerDetailInfo.js
@@ -11,6 +11,7 @@ const BeerDetailWrapper = styled.section`
     width: 10%;
     height: 10%;
     margin-left: 40px;
+    margin-top: 20px;
   }
 `;
 
@@ -68,6 +69,8 @@ const BeerDetailInfo = ({ isModalVisible, handleChangeVisible, target }) => {
       visible={isModalVisible}
       onCancel={handleCancel}
       width={1000}
+      cancelButtonProps={{ style: { display: "none" } }}
+      okButtonProps={{ style: { display: "none" } }}
     >
       <BeerDetailWrapper>
         <img src={targetBeer.image_url} alt={targetBeer.tagline} />

--- a/src/Components/WishCard.js
+++ b/src/Components/WishCard.js
@@ -1,0 +1,78 @@
+import React from "react";
+import { useDispatch } from "react-redux";
+import styled from "styled-components";
+import { Card } from "antd";
+import { DeleteOutlined } from "@ant-design/icons";
+import { removeWishList } from "../Modules/Reducers/beers";
+import BeerDetailInfo from "./BeerDetailInfo";
+
+const WishCardWrapper = styled.div`
+  margin: 10px;
+  text-align: center;
+`;
+
+const BeerCard = styled(Card)`
+  width: 200px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const ImageWrapper = styled.div`
+  margin-top: 50px;
+`;
+
+const Image = styled.img`
+  width: 25%;
+  height: 25%;
+`;
+
+const RemoveIcon = styled(DeleteOutlined)`
+  margin-top: 20px;
+  font-size: 20px;
+
+  :hover {
+    color: #b71c1c;
+  }
+`;
+
+const WishCard = ({ cardInfo, isModalVisible, handleChangeVisible }) => {
+  const dispatch = useDispatch();
+
+  const handleClickRemove = (id) => {
+    dispatch(removeWishList(id));
+  };
+
+  const handleClickMore = () => {
+    handleChangeVisible(true);
+  };
+
+  return (
+    <WishCardWrapper>
+      <BeerDetailInfo
+        isModalVisible={isModalVisible}
+        handleChangeVisible={handleChangeVisible}
+        target={cardInfo.name}
+      />
+      <BeerCard
+        hoverable
+        extra={
+          <a onClick={handleClickMore} href="#!">
+            More
+          </a>
+        }
+        cover={
+          <ImageWrapper>
+            <Image alt={cardInfo.tagline} src={cardInfo.image_url} />
+          </ImageWrapper>
+        }
+      >
+        <Card.Meta title={cardInfo.name} description={cardInfo.tagline} />
+        <RemoveIcon onClick={() => handleClickRemove(cardInfo.id)} />
+      </BeerCard>
+    </WishCardWrapper>
+  );
+};
+
+export default WishCard;

--- a/src/Modules/Reducers/beers.js
+++ b/src/Modules/Reducers/beers.js
@@ -2,6 +2,7 @@ const initialState = {
   isLoading: false,
   beerList: [],
   beerTableColumns: [],
+  wishList: [],
 };
 
 // action creator
@@ -21,6 +22,20 @@ export const setBeerTableColumns = (data) => {
 export const changeBeerTableColumn = (data) => {
   return {
     type: "CHANGE_BEER_TABLE_COLUMN",
+    data,
+  };
+};
+
+export const setWishList = (data) => {
+  return {
+    type: "SET_WISH_LIST",
+    data,
+  };
+};
+
+export const removeWishList = (data) => {
+  return {
+    type: "REMOVE_WISH_LIST",
     data,
   };
 };
@@ -61,6 +76,18 @@ const reducer = (state = initialState, action) => {
       return {
         ...state,
         beerTableColumns: [...state.beerTableColumns],
+      };
+    case "SET_WISH_LIST":
+      return {
+        ...state,
+        wishList: [...state.wishList, action.data],
+      };
+    case "REMOVE_WISH_LIST":
+      const removeIdx = state.wishList.findIndex((v) => v === action.data);
+      state.wishList.splice(removeIdx, 1);
+      return {
+        ...state,
+        wishList: [...state.wishList],
       };
     default:
       return state;

--- a/src/Pages/BeerList.js
+++ b/src/Pages/BeerList.js
@@ -4,12 +4,14 @@ import {
   getBeerList,
   setBeerTableColumns,
   changeBeerTableColumn,
+  setWishList,
 } from "../Modules/Reducers/beers";
 import { useDispatch, useSelector } from "react-redux";
 import MaterialTable from "material-table";
 import styled from "styled-components";
 import BeerDetailInfo from "../Components/BeerDetailInfo";
 import { Spin, Select } from "antd";
+import { ShoppingCartOutlined, CheckCircleOutlined } from "@ant-design/icons";
 
 const BeerListTableWrapper = styled.div`
   margin: 5% 20% 5% 20%;
@@ -20,14 +22,31 @@ const Loading = styled(Spin)`
   margin-top: 250px;
 `;
 
+const WishListIcon = styled(ShoppingCartOutlined)`
+  font-size: 20px;
+  margin-left: 30px;
+
+  :hover {
+    color: #ffab00;
+  }
+`;
+
+const CheckWishListIcon = styled(CheckCircleOutlined)`
+  font-size: 20px;
+  margin-left: 30px;
+  color: #c8c8c8;
+`;
+
 const BeerList = () => {
   const dispatch = useDispatch();
   const beerList = useSelector((state) => state.beers.beerList);
   const beerTableColumns = useSelector((state) => state.beers.beerTableColumns);
   const isLoading = useSelector((state) => state.beers.isLoading);
+  const wishList = useSelector((state) => state.beers.wishList);
 
   const data = beerList.map((info) => {
     return {
+      id: info.id,
       name: info.name,
       abv: info.abv,
       summary: info.tagline,
@@ -56,6 +75,40 @@ const BeerList = () => {
       title: "SUMMARY",
       field: "summary",
     },
+    {
+      id: 4,
+      title: "Add Wish List",
+      render: (row) =>
+        wishList.includes(row.id) ? (
+          <CheckWishListIcon />
+        ) : (
+          <WishListIcon onClick={() => handleClickAddWishList(row.id)} />
+        ),
+    },
+  ];
+
+  const customIcons = [
+    {
+      onClick: () => {}, // Handle error: Invalid prop `actions[0]` supplied to `MaterialTable`
+      isFreeAction: true,
+      tooltip: "Filter by abv",
+      icon: () => (
+        <Select
+          defaultValue="All"
+          style={{ width: 100 }}
+          onChange={handleChangeSelectedAdv}
+        >
+          {["All", 1, 2, 3, 4, 5, 6, 7].map((v) => (
+            <Select.Option
+              key={v}
+              value={v === "All" ? "All" : `${v}~${v + 1}`}
+            >
+              {v === "All" ? "All" : `${v}~${v + 1}`}
+            </Select.Option>
+          ))}
+        </Select>
+      ),
+    },
   ];
 
   const [isModalVisible, setIsModalVisible] = useState(false);
@@ -76,6 +129,10 @@ const BeerList = () => {
         : data.filter((v) => start <= v.abv && v.abv < end)
     );
   }, [selectedAdv]);
+
+  const handleClickAddWishList = (id) => {
+    dispatch(setWishList(id));
+  };
 
   const handleChangeSelectedAdv = (value) => {
     setSelectedAdv(value);
@@ -109,29 +166,7 @@ const BeerList = () => {
             title="Beer List: Click! on a beer name to see details🍺"
             options={{ paging: false }}
             onColumnDragged={handleColumnDragged}
-            actions={[
-              {
-                onClick: () => {}, // Handle error: Invalid prop `actions[0]` supplied to `MaterialTable`
-                isFreeAction: true,
-                tooltip: "Filter by abv",
-                icon: () => (
-                  <Select
-                    defaultValue="All"
-                    style={{ width: 100 }}
-                    onChange={handleChangeSelectedAdv}
-                  >
-                    {["All", 1, 2, 3, 4, 5, 6, 7].map((v) => (
-                      <Select.Option
-                        key={v}
-                        value={v === "All" ? "All" : `${v}~${v + 1}`}
-                      >
-                        {v === "All" ? "All" : `${v}~${v + 1}`}
-                      </Select.Option>
-                    ))}
-                  </Select>
-                ),
-              },
-            ]}
+            actions={customIcons}
           />
         )}
         {isModalVisible && (

--- a/src/Pages/WishList.js
+++ b/src/Pages/WishList.js
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import styled from "styled-components";
+import Layout from "../Components/Layout";
+import WishCard from "../Components/WishCard";
+import { useSelector } from "react-redux";
+import { Empty } from "antd";
+
+const WishListWrapper = styled.section`
+  margin: 5% 20% 5% 20%;
+  h1 {
+    font-size: 30px;
+    font-weight: bolder;
+  }
+`;
+
+const WishCards = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`;
+
+const EmptyWishList = styled(Empty)`
+  margin-top: 150px;
+`;
+
+const WishList = () => {
+  const wishList = useSelector((state) => state.beers.wishList);
+  const beerList = useSelector((state) => state.beers.beerList);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  return (
+    <Layout>
+      <WishListWrapper>
+        <h1>🛒 Wish List:</h1>
+        {wishList.length ? (
+          <WishCards>
+            {wishList.map((id) => {
+              const cardInfo = beerList.find((v) => v.id === id);
+              return (
+                <WishCard
+                  key={id + Math.random()}
+                  cardInfo={cardInfo}
+                  isModalVisible={isModalVisible}
+                  handleChangeVisible={setIsModalVisible}
+                />
+              );
+            })}
+          </WishCards>
+        ) : (
+          <EmptyWishList />
+        )}
+      </WishListWrapper>
+    </Layout>
+  );
+};
+
+export default WishList;

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -7,6 +7,7 @@ import {
 } from "react-router-dom";
 import Home from "./Pages/Home";
 import BeerList from "./Pages/BeerList";
+import WishList from "./Pages/WishList";
 
 const Routes = () => {
   useEffect(() => {
@@ -23,6 +24,7 @@ const Routes = () => {
       <Switch>
         <Route path="/home" component={Home} />
         <Route path="/beer-list" component={BeerList} />
+        <Route path="/wish-list" component={WishList} />
         <Redirect path="*" to="/home" />
       </Switch>
     </Router>


### PR DESCRIPTION
## Job Description
- Create wish list page
- beer list page의 beers table 각 row에 wish list 추가 버튼 생성
- Redux store에 wish list 상태 저장(id만 저장)
- wish list page에서 wish list 렌더링
- wish list page에서 각 beer card에 삭제 버튼 생성
- 삭제 버튼 클릭시 Redux store에서 해당 card를 삭제
- 각 Card에 'More' a tag 생성 'More' 클릭시 modal(BeerDetailInfo Component) 재사용

#8 